### PR TITLE
Fix breadcrumb URLs

### DIFF
--- a/controllers/channels/create.htm
+++ b/controllers/channels/create.htm
@@ -1,6 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
-        <li><a href="<?= Backend::url('backend/system/settings') ?>">Settings</a></li>
+        <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
         <li><a href="<?= Backend::url('rainlab/forum/channels') ?>">Channels</a></li>
         <li><?= e($this->pageTitle) ?></li>
     </ul>

--- a/controllers/channels/index.htm
+++ b/controllers/channels/index.htm
@@ -1,6 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
-        <li><a href="<?= Backend::url('backend/system/settings') ?>">Settings</a></li>
+        <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
         <li><?= e($this->pageTitle) ?></li>
     </ul>
 <?php Block::endPut() ?>

--- a/controllers/channels/preview.htm
+++ b/controllers/channels/preview.htm
@@ -1,6 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
-        <li><a href="<?= Backend::url('backend/system/settings') ?>">Settings</a></li>
+        <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
         <li><a href="<?= Backend::url('rainlab/forum/channels') ?>">Channels</a></li>
         <li><?= e($this->pageTitle) ?></li>
     </ul>

--- a/controllers/channels/reorder.htm
+++ b/controllers/channels/reorder.htm
@@ -1,6 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
-        <li><a href="<?= Backend::url('backend/system/settings') ?>">Settings</a></li>
+        <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
         <li><a href="<?= Backend::url('rainlab/forum/channels') ?>">Channels</a></li>
         <li><?= e($this->pageTitle) ?></li>
     </ul>

--- a/controllers/channels/update.htm
+++ b/controllers/channels/update.htm
@@ -1,6 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
-        <li><a href="<?= Backend::url('backend/system/settings') ?>">Settings</a></li>
+        <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
         <li><a href="<?= Backend::url('rainlab/forum/channels') ?>">Channels</a></li>
         <li><?= e($this->pageTitle) ?></li>
     </ul>


### PR DESCRIPTION
When calling Backend::url() you don't need to specify the `backend/` prefix.
