### PR TITLE
Only add forum_member_username column to User list

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -65,6 +65,7 @@ class Plugin extends PluginBase
 
         Event::listen('backend.list.extendColumns', function($widget) {
             if (!$widget->getController() instanceof \RainLab\User\Controllers\Users) return;
+            if (!$widget->model instanceof \RainLab\User\Models\User) return;
 
             $widget->addColumns([
                 'forum_member_username' => [


### PR DESCRIPTION
I'm trying to display my own Lists widget inside the User edit form for a plugin, however your `backend.list.extendColumns` event is triggering and adding a column to my model's List that doesn't exist in the model. You should only be adding the `forum_member_username` column to the User model's list.
