### PR TITLE
Fix mismatch lang reference in Topic component

### DIFF
--- a/components/Topic.php
+++ b/components/Topic.php
@@ -64,7 +64,7 @@ class Topic extends ComponentBase
     {
         return [
             'name'        => 'rainlab.forum::lang.topicpage.name',
-            'description' => 'rainlab.forum::lang.topicpage.desc'
+            'description' => 'rainlab.forum::lang.topicpage.self_desc'
         ];
     }
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -112,7 +112,7 @@ return [
     ],
     'topicpage' => [
         'name' => 'Topic',
-        'self' => 'Displays a topic and posts.',
+        'self_desc' => 'Displays a topic and posts.',
         'slug_name' => 'Slug param name',
         'slug_desc' => 'The URL route parameter used for looking up the topic by its slug. A hard coded slug can also be used.',
         'channel_title' => 'Channel Page',


### PR DESCRIPTION
Topic component lang key was `self` and component referenced `desc`.  Channel uses `self_desc` so just made it consistent for Topic.