### PR TITLE
Update Plugin.php

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -41,6 +41,8 @@ class Plugin extends PluginBase
         });
 
         UsersController::extendFormFields(function($widget, $model, $context) {
+            // Prevent extending of related form instead of the intended User form
+            if (!$widget->model instanceof \RainLab\User\Models\User) return;
             if ($context != 'update') return;
             if (!Member::getFromUser($model)) return;
 


### PR DESCRIPTION
Prevent extending of related form instead of the intended User form.  This was the cause of my cellphone plugin form having unrelated fields injected and causing errors.