### PR TITLE
Show topic start member on topic and channel component.

### DIFF
--- a/components/Channel.php
+++ b/components/Channel.php
@@ -146,6 +146,9 @@ class Channel extends ComponentBase
 
                 if ($topic->last_post_member)
                     $topic->last_post_member->setUrl($this->memberPage, $this->controller);
+                    
+                if ($topic->start_member)
+                    $topic->start_member->setUrl($this->memberPage, $this->controller);
             });
 
             /*

--- a/components/Topics.php
+++ b/components/Topics.php
@@ -109,6 +109,9 @@ class Topics extends ComponentBase
 
             if ($topic->last_post_member)
                 $topic->last_post_member->setUrl($this->memberPage, $this->controller);
+                
+            if ($topic->start_member)
+                $topic->start_member->setUrl($this->memberPage, $this->controller);
         });
 
         /*

--- a/components/channel/topics.htm
+++ b/components/channel/topics.htm
@@ -16,6 +16,7 @@
                     {% if topic.is_sticky %}<strong>Sticky:</strong>{% endif %}
                     {% if topic.is_locked %}<i class="icon icon-lock"></i> <strong>Locked:</strong>{% endif %}
                     <a href="{{ topic.url }}">{{ topic.subject }}</a>
+                    <br/><small>by <a href="{{ topic.start_member.url }}">{{ topic.start_member.username }}</a></small>
                 </h5>
             </td>
             <td class="counter-column">

--- a/components/topics/topics.htm
+++ b/components/topics/topics.htm
@@ -15,6 +15,7 @@
                     {% if topic.sticky %}<strong>Sticky:</strong>{% endif %}
                     {% if topic.locked %}<strong>Locked:</strong>{% endif %}
                     <a href="{{ topic.url }}">{{ topic.subject }}</a>
+                    <br/><small>by <a href="{{ topic.start_member.url }}">{{ topic.start_member.username }}</a></small>
                 </h5>
             </td>
             <td>


### PR DESCRIPTION
Since start_member is within the model of a topic I think they should be populated within the channel and topic component. 
Subsequently, showing the topic author on the topic and channel list would make the forum more like any other popular forums (phpbb, smf).

Sorry it was in 4 commits. I edited each file from the browser, since it was a simple addition. Feel free to take the changes and make your own commit.