### PR TITLE
Add long date and time to human date diffs

### DIFF
--- a/components/channel/topics.htm
+++ b/components/channel/topics.htm
@@ -30,7 +30,10 @@
                     <img src="{{ topic.last_post_member.user.avatarThumb(24) }}" class="member-avatar" />
                     <a href="{{ topic.last_post_member.url }}">{{ topic.last_post_member.username }}</a>
                     <small>
-                        posted <a href="{{ topic.url }}?page=last#post-{{ topic.last_post_id }}">{{ topic.last_post_at.diffForHumans }}</a>
+                        posted
+                        <a href="{{ topic.url }}?page=last#post-{{ topic.last_post_id }}">
+                            {% partial __SELF__ ~ "::timestamp" date=topic.last_post_at %}
+                        </a>
                     </small>
                 </p>
             </td>

--- a/components/channels/default.htm
+++ b/components/channels/default.htm
@@ -53,9 +53,11 @@
                             {% if channel.first_topic %}
                                 <p>
                                     <a href="{{ channel.first_topic.url }}?page=last#post-{{ channel.first_topic.last_post_id }}">
-                                       {{ channel.first_topic.subject }}
-                                   </a>
-                                   <small>{{ channel.first_topic.last_post_at.diffForHumans }}</small>
+                                        {{ channel.first_topic.subject }}
+                                    </a>
+                                    <small>
+                                        {% partial __SELF__ ~ "::timestamp" date=channel.first_topic.last_post_at %}
+                                    </small>
                                 </p>
                             {% endif %}
                         </td>

--- a/components/member/recentposts.htm
+++ b/components/member/recentposts.htm
@@ -16,7 +16,7 @@
                 <p>
                     Posted in
                     <a href="{{ topic.url }}?page=last#post-{{ post.id }}">{{ topic.subject }}</a>
-                    {{ post.updated_at.diffForHumans }}
+                    {% partial __SELF__ ~ "::timestamp" date=post.updated_at %}
                 </p>
             </td>
         </tr>

--- a/components/partials/timestamp.htm
+++ b/components/partials/timestamp.htm
@@ -1,0 +1,4 @@
+<time title="{{ date.toDayDateTimeString }}"
+    datetime="{{ date|date('c') }}">
+    {{ date.diffForHumans }}
+</time>

--- a/components/topic/post.htm
+++ b/components/topic/post.htm
@@ -5,7 +5,9 @@
     <a href="{{ post.member.url }}" class="author">{{ post.member.username }}</a>
     <div class="metadata">
         <div class="date">
-            <a href="#post-{{ post.id }}">{{ post.created_at.diffForHumans }}</a>
+            <a href="#post-{{ post.id }}">
+                {% partial __SELF__ ~ "::timestamp" date=post.created_at %}
+            </a>
         </div>
         {% if post.member.is_banned %}
             <div class="status text-danger">
@@ -75,7 +77,9 @@
             {{ post.content_html|raw }}
 
             {% if post.created_at != post.updated_at %}
-                <p><small class="text text-muted">Last updated {{ post.updated_at.diffForHumans }}</small></p>
+                <p><small class="text text-muted">
+                    Last updated {% partial __SELF__ ~ "::timestamp" date=post.updated_at %}
+                </small></p>
             {% endif %}
         </div>
         <div class="actions">

--- a/components/topics/topics.htm
+++ b/components/topics/topics.htm
@@ -26,7 +26,9 @@
                     <img src="{{ topic.last_post_member.user.avatarThumb(24) }}" class="member-avatar" />
                     <a href="{{ topic.last_post_member.url }}">{{ topic.last_post_member.username }}</a>
                     posted
-                    <a href="{{ topic.url }}?page=last#post-{{ topic.last_post_id }}">{{ topic.last_post_at.diffForHumans }}</a>
+                    <a href="{{ topic.url }}?page=last#post-{{ topic.last_post_id }}">
+                        {% partial __SELF__ ~ "::timestamp" date=topic.last_post_at %}
+                    </a>
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
Does what it says on the tin. Human diffs are a bit vague after a while, so this adds the long format on hover.

### Example

> [Jill](#) posted [6 months ago](# "July 8th, 2016 at 1:37pm")