### PR TITLE
Adding Moderation For Topic Creation.

### DIFF
--- a/components/Topic.php
+++ b/components/Topic.php
@@ -306,6 +306,10 @@ class Topic extends ComponentBase
 
             $member = $this->getMember();
             $channel = $this->getChannel();
+            
+            if ($channel->is_moderated && !$member->is_moderator) {
+                throw new ApplicationException('You cannot create a topic in this channel.');
+            }
 
             if (TopicModel::checkThrottle($member)) {
                 throw new ApplicationException('Please wait a few minutes before posting another topic.');


### PR DESCRIPTION
"Only moderators can post to this channel." being checked did not work as advertised. This adds functionality to restrict new Topics to mods. All can reply.