### PR TITLE
Resolved Exception on PHP 7.3

### DIFF
--- a/classes/TopicTracker.php
+++ b/classes/TopicTracker.php
@@ -187,6 +187,7 @@ class TopicTracker
             switch (substr($idData, 0, 1)) {
                 case 'c': $type = 'channels'; break;
                 case 't': $type = 'topics'; break;
+                default: continue 2;
             }
 
             $id = intval(substr($idData, 1));

--- a/classes/TopicTracker.php
+++ b/classes/TopicTracker.php
@@ -187,7 +187,6 @@ class TopicTracker
             switch (substr($idData, 0, 1)) {
                 case 'c': $type = 'channels'; break;
                 case 't': $type = 'topics'; break;
-                default: continue;
             }
 
             $id = intval(substr($idData, 1));


### PR DESCRIPTION
# Exception

Exception can be replicated by logging in through "Users" plugin and visiting a page containing one of the following components:

*   Embed Topic
*   Channel
*   Channel List

![Exception](https://i.imgur.com/bePdObz.png)

This exception only occurs on servers running specific version PHP, version 7.3.

**Migration link:** [http://php.net/manual/en/migration73.php](http://php.net/manual/en/migration73.php)

# Details

I'm hosting an instance of OctoberCMS (build 447) on a server running a generic LAMP stack.

![CMS Details](https://i.imgur.com/fLLhDr5.png)

## Server Details

| Tech           | Version                              |
|----------------|--------------------------------------|
| Linux Kernel   | 2.6.32-896.16.1.lve1.4.54.el6 |
| Apache Version | 2.4.25                               |
| MySQL Version  | 5.6.39                               |
| PHP Version    | 7.3.0                                |

**Server architecture is:** x86_64

## Active Plugins

Following plugins are active on my instance.

| Plugin                  | Version | Updates | Enabled |
|-------------------------|---------|---------|---------|
| October.Demo            | 1.0.1   | Yes     | No      |
| RainLab.Pages           | 1.2.20  | Yes     | Yes     |
| RainLab.Blog            | 1.3.1   | Yes     | Yes     |
| RainLab.Translate       | 1.4.5   | Yes     | Yes     |
| RainLab.GoogleAnalytics | 1.2.3   | Yes     | Yes     |
| AnandPatel.SeoExtension | 1.0.6   | Yes     | Yes     |
| RainLab.Sitemap         | 1.0.8   | Yes     | Yes     |
| RainLab.User            | 1.4.6   | Yes     | Yes     |
| RainLab.Location        | 1.1.2   | Yes     | Yes     |
| RainLab.UserPlus        | 1.1.0   | Yes     | Yes     |
| RainLab.Notify          | 1.0.2   | Yes     | Yes     |
| RainLab.Forum           | 1.2.0   | Yes     | Yes     |